### PR TITLE
Adds tags to all yml samples' 'uses:' occurrences.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ jobs:
         with:
           dotnet-version: 5.0.x
 
-      - uses: retypeapp/action-build
+      - uses: retypeapp/action-build@v1
 
-      - uses: retypeapp/action-github-pages
+      - uses: retypeapp/action-github-pages@v1
         with:
           branch: retype
           update-branch: true
@@ -131,7 +131,7 @@ jobs:
 
       - uses: retypeapp/action-build@v1
 
-      - uses: retypeapp/action-github-pages
+      - uses: retypeapp/action-github-pages@v1
         with:
           branch: retype
           update-branch: true
@@ -142,7 +142,7 @@ The `retypeapp/action-build` is a required step before running the `retypeapp/ac
 ### Most common setup
 
 ```yaml
-- uses: retypeapp/action-github-pages
+- uses: retypeapp/action-github-pages@v1
   with:
     branch: retype
     update-branch: true
@@ -153,7 +153,7 @@ The `retypeapp/action-build` is a required step before running the `retypeapp/ac
 In this example we will push to a `gh-pages` branch and allow the action to use its own access token to create the pull request whenever the branch exists.
 
 ```yaml
-- uses: retypeapp/action-github-pages
+- uses: retypeapp/action-github-pages@v1
   with:
     branch: gh-pages
     github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -175,7 +175,7 @@ GitHub Pages is not automatically configured by the action pushing to the `gh-pa
 This example assumes GitHub Pages was configured to serve pages from the `docs` folder from within the root of the `main`.
 
 ```yaml
-- uses: retypeapp/action-github-pages
+- uses: retypeapp/action-github-pages@v1
   with:
     branch: main
     directory: docs
@@ -206,9 +206,9 @@ jobs:
         with:
           dotnet-version: 5.0.x
 
-      - uses: retypeapp/action-build
+      - uses: retypeapp/action-build@v1
 
-      - uses: retypeapp/action-github-pages
+      - uses: retypeapp/action-github-pages@v1
         with:
           branch: main
           directory: docs
@@ -238,9 +238,9 @@ jobs:
         with:
           dotnet-version: 5.0.x
 
-      - uses: retypeapp/action-build
+      - uses: retypeapp/action-build@v1
 
-      - uses: retypeapp/action-github-pages
+      - uses: retypeapp/action-github-pages@v1
         with:
           branch: retype
           update-branch: true


### PR DESCRIPTION
Not having an explicit tag would mean it should pull the default branch
which, for some reason (according to retypeapp/retype#248) GitHub
actions didn't accept the `owner/repo` path without '@ref' instead of
choosing default branch (which should work just like '@v1' would).

Nevertheless it was never supposed to be documented the way it is and we
have long conventioned to use the '@v1' tag, so with this the
documentation is also conforming to our (and GitHub actions') standards.